### PR TITLE
Update expected Bali release version

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ currently is following a roughly six month release cadence.
      * Release Date
 
    - * :doc:`bali/index`
-     * v0.3 (planned)
+     * v0.4 (planned)
      * Under Development
      * 2018-12-10 (planned)
 


### PR DESCRIPTION
To better differentiate between the interim development builds and the
final Bali release, this updates the expected Bali version to 0.4.0.
This makes it more clear that the 0.3.x versions were milestone
development releases, and anything after 0.4.0 will be official Bali or
stable update releases.